### PR TITLE
fix: UnicodeDecodeError when pip install on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 def setup_package():
     root = Path(__file__).parent.resolve()
 
-    with open(root / "requirements-dev.txt") as file:
+    with open(root / "requirements-dev.txt", encoding="utf8") as file:
         DEVELOPMENT_MODULES = [line.strip()
                                for line in file if "-e" not in line]
     extras = {"dev": DEVELOPMENT_MODULES}
@@ -20,7 +20,7 @@ def setup_package():
         author_email="",
         url="https://github.com/pharmapsychotic/BLIP",
         description="BLIP library for use with CLIP Interrogator",
-        long_description=open('README.md').read(),
+        long_description=open('README.md', encoding="utf8").read(),
         long_description_content_type="text/markdown",
         packages=find_packages(),
         install_requires=[


### PR DESCRIPTION
fix by adding encoding field to two open functions

When I `pip install blip-ci` on Windows, get `UnicodeDecodeError: 'gbk'codec can't decode byte 0xa4 in position 1326: illegal multibyte sequence`

![image](https://user-images.githubusercontent.com/31330732/220542415-be4a1076-1161-4ce6-affb-9190bb1ec7aa.png)

After changing the encoding:

![image](https://user-images.githubusercontent.com/31330732/220542697-a544187e-be47-4acf-9c6c-fb65b6b92ac8.png)
